### PR TITLE
yelp initialization for categories + mapped transactions to specific …

### DIFF
--- a/backend/expenses/merchantCategories.js
+++ b/backend/expenses/merchantCategories.js
@@ -1,0 +1,83 @@
+const { getYelpCategory } = require("./yelpCategorize");
+const { PrismaClient } = require("../generated/prisma");
+const prisma = new PrismaClient();
+
+async function categorizeTransaction(merchantName, userId) {
+  // check if this merchant is already categorized
+  const existingMerchant = await prisma.merchantCategory.findFirst({
+    where: {
+      merchantName: merchantName,
+      userId: userId,
+    },
+    include: { category: true },
+  });
+
+  if (existingMerchant) {
+    // update lastUsed timestamp
+    await prisma.merchantCategory.update({
+      where: { id: existingMerchant.id },
+      data: { lastUsed: new Date() },
+    });
+
+    return existingMerchant.category;
+  }
+
+  // if no existing merchant get the category from yelp
+
+  const yelpData = await getYelpCategory(merchantName);
+
+  if (
+    !yelpData ||
+    !yelpData.yelp_categories ||
+    yelpData.yelp_categories.length === 0
+  ) {
+    console.log(`No Yelp categories found for ${merchantName}`);
+    // uncategorized for merchants that didnt fit into either one
+    const uncategorized = await getOrCreateCategory("Uncategorized", userId);
+    await createMerchantCategory(merchantName, uncategorized.id, userId);
+    return uncategorized;
+  }
+
+  // uses the first Yelp category
+  const primaryCategory = yelpData.yelp_categories[0];
+  const category = await getOrCreateCategory(primaryCategory, userId);
+
+  // merchant category association
+  await createMerchantCategory(merchantName, category.id, userId);
+  return category;
+}
+// gets or creates a category
+async function getOrCreateCategory(categoryName, userId) {
+  const existingCategory = await prisma.category.findFirst({
+    where: {
+      name: categoryName,
+      userId: userId,
+    },
+  });
+
+  if (existingCategory) {
+    return existingCategory;
+  }
+
+  return await prisma.category.create({
+    data: {
+      name: categoryName,
+      userId: userId,
+    },
+  });
+}
+// create merchant category association
+async function createMerchantCategory(merchantName, categoryId, userId) {
+  return await prisma.merchantCategory.create({
+    data: {
+      merchantName: merchantName,
+      // normalized names for name matching 
+      normalized: merchantName.toLowerCase().replace(/[^a-z0-9]/g, ""),
+      categoryId: categoryId,
+      userId: userId,
+      lastUsed: new Date(),
+    },
+  });
+}
+
+module.exports = { categorizeTransaction };

--- a/backend/expenses/yelpCategorize.js
+++ b/backend/expenses/yelpCategorize.js
@@ -1,0 +1,39 @@
+require("dotenv").config();
+const axios = require("axios");
+
+async function getYelpCategory(businessName, location = "San Francisco, CA") {
+  const apiKey = process.env.YELP_API_KEY;
+
+  const url = `https://api.yelp.com/v3/businesses/search`;
+  const headers = {
+    Authorization: `Bearer ${apiKey}`,
+  };
+
+  const params = {
+    term: businessName,
+    location: location,
+    limit: 1,
+  };
+
+  try {
+    const response = await axios.get(url, { headers, params });
+    const business = response.data.businesses[0];
+
+    if (!business) {
+      console.log(`No results found`);
+      return null;
+    }
+
+    const categoryLabels = business.categories.map((c) => c.title);
+
+    return {
+      name: business.name,
+      yelp_categories: categoryLabels,
+    };
+  } catch (error) {
+    console.error("Yelp API error:", error.message);
+    return null;
+  }
+}
+
+module.exports = { getYelpCategory };

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -27,6 +27,8 @@ model User {
   reminders        Reminder[]
   transactions     Transaction[]
   avoidedMerchants AvoidedMerchant[]
+  merchants        MerchantCategory[]
+  categories       Category[]
 }
 
 model Transaction {
@@ -91,4 +93,24 @@ model AvoidedMerchant {
   user         User     @relation(fields: [userId], references: [id])
   
   @@unique([userId, merchantName])
+}
+
+model Category {
+  id           String   @id @default(cuid())
+  name         String
+  userId       String
+  user         User     @relation(fields: [userId], references: [id])
+  merchants    MerchantCategory[]
+}
+
+model MerchantCategory {
+  id                 String   @id @default(cuid())
+  merchantName       String
+  normalized         String
+  categoryId         String
+  userId             String
+  lastUsed           DateTime @default(now())
+
+  category           Category @relation(fields: [categoryId], references: [id])
+  user               User     @relation(fields: [userId], references: [id])
 }


### PR DESCRIPTION
…categories

## Description

In this PR I have initialized the Yelp API and used it to map categories to different transactions.
In later PRs, i will be creating a personal list of categories that the user can add to and edit, and Implementing this on the frontend.

## Milestones
TC 2

## Resources
https://axios-http.com/docs/intro
https://docs.developer.yelp.com/docs/fusion-intro


## Test Plan
I have not yet implemented this on the frontend, but I tested this through the backend console. returning transactions to ensure the category was mapped.
